### PR TITLE
Fix parsing error when month is '0' or '00'

### DIFF
--- a/lib/timeliness/helpers.rb
+++ b/lib/timeliness/helpers.rb
@@ -22,7 +22,7 @@ module Timeliness
     end
     
     def month_index(month)
-      return month.to_i if month.to_i > 0
+      return month.to_i if month.to_i > 0 || /0+/ =~ month
       month.length > 3 ? month_names.index(month.capitalize) : abbr_month_names.index(month.capitalize)
     end
 

--- a/spec/timeliness/format_spec.rb
+++ b/spec/timeliness/format_spec.rb
@@ -29,6 +29,14 @@ describe Timeliness::Format do
       format_for('dd/mm/yyyy').process('2', '1', '2000').should == [2000,1,2,nil,nil,nil,nil,nil]
     end
 
+    it "should define method which outputs date array with zeros when month and day are '0'" do
+      format_for('m/d/yy').process('0', '0', '0000').should == [0,0,0,nil,nil,nil,nil,nil]
+    end
+
+    it "should define method which outputs date array with zeros when month and day are '00'" do
+      format_for('m/d/yy').process('00', '00', '0000').should == [0,0,0,nil,nil,nil,nil,nil]
+    end
+
     it "should define method which outputs time array" do
       format_for('hh:nn:ss').process('01', '02', '03').should == [nil,nil,nil,1,2,3,nil,nil]
     end

--- a/spec/timeliness/parser_spec.rb
+++ b/spec/timeliness/parser_spec.rb
@@ -31,6 +31,14 @@ describe Timeliness::Parser do
       should_not_parse("2000-02-30")
     end
 
+    it "should return nil for invalid date string where month is '0'" do
+      should_not_parse("0/01/2000")
+    end
+
+    it "should return nil for invalid date string where month is '00'" do
+      should_not_parse("00/01/2000")
+    end
+
     it "should return time object for valid time string" do
       parse("12:13:14").should be_kind_of(Time)
     end
@@ -123,6 +131,10 @@ describe Timeliness::Parser do
       it "should return time object for valid datetime string" do
         parse("2000-01-01 12:13:14", :datetime).should == Time.local(2000,1,1,12,13,14)
       end
+
+      it "should return nil for invalid date string" do
+        parse("0/01/2000", :datetime).should be_nil
+      end
     end
 
     context "with :date type" do
@@ -132,6 +144,10 @@ describe Timeliness::Parser do
 
       it "should ignore time in datetime string" do
         parse('2000-02-01 12:13', :date).should == Time.local(2000,2,1)
+      end
+
+      it "should return nil for invalid date string" do
+        parse("0/01/2000", :date).should be_nil
       end
     end
 


### PR DESCRIPTION
Hi,

Timeliness doesn't seem to like parsing '0' or '00' as month values.  In such cases, Timeliness::Parser.parse should simply return nil because the date string is invalid.  But here is what currently happens in a few cases:

``` ruby
Loading development environment (Rails 3.0.7)
ree-1.8.7-2010.02 > Timeliness::Parser.parse('00/01/11')
 => Sat Jan 01 00:00:00 UTC 2011 
ree-1.8.7-2010.02 > Timeliness::Parser.parse('0/01/11')
 => Sat Jan 01 00:00:00 UTC 2011 
ree-1.8.7-2010.02 > Timeliness::Parser.parse('00/01/11', :date)
NoMethodError: undefined method `<' for nil:NilClass
    from /.../gems/activesupport-3.0.7/lib/active_support/whiny_nil.rb:48:in `method_missing'
    from /.../gems/timeliness-0.3.4/lib/timeliness/parser.rb:142:in `fast_date_valid_with_fallback'
    from /.../gems/timeliness-0.3.4/lib/timeliness/parser.rb:24:in `make_time'
    from /.../gems/timeliness-0.3.4/lib/timeliness/parser.rb:17:in `parse_without_date_conversion'
ree-1.8.7-2010.02 > Timeliness::Parser.parse('00/01/11', :datetime)
NoMethodError: undefined method `<' for nil:NilClass
    from /.../gems/activesupport-3.0.7/lib/active_support/whiny_nil.rb:48:in `method_missing'
    from /.../gems/timeliness-0.3.4/lib/timeliness/parser.rb:142:in `fast_date_valid_with_fallback'
    from /.../gems/timeliness-0.3.4/lib/timeliness/parser.rb:24:in `make_time'
    from /../gems/timeliness-0.3.4/lib/timeliness/parser.rb:17:in `parse_without_date_conversion'
```

This pull request attempts address the issue at what I think is the root cause in Timeliness::Helpers.month_index.  That method does not differentiate between '0'.to_i and '<any other string>'.to_i, which both return 0.  

Please consider including it in your next release.

Thanks,
Jim
