### PR TITLE
Add license name to the gemspec.

### DIFF
--- a/timeliness.gemspec
+++ b/timeliness.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = %q{http://github.com/adzap/timeliness}
   s.summary     = %q{Date/time parsing for the control freak.}
   s.description = %q{Fast date/time parser with customisable formats, timezone and I18n support.}
+  s.license     = "MIT"
 
   s.rubyforge_project = %q{timeliness}
 


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.