### PR TITLE
Store format_set in a threadsafe way

### DIFF
--- a/lib/threadsafe_attr.rb
+++ b/lib/threadsafe_attr.rb
@@ -1,21 +1,22 @@
 module ThreadsafeAttr
   def threadsafe_attr_accessor(*attrs)
     attrs.each do |attr|
-      reader attr
-      writer attr
+      storage_name = "#{name}.#{attr}".freeze
+      reader attr, storage_name
+      writer attr, storage_name
     end
   end
 
   private
-  def reader(attr)
+  def reader(attr, storage_name)
     define_method(attr) do
-      Thread.current["#{self.name}.#{attr}"]
+      Thread.current[storage_name]
     end
   end
 
-  def writer(attr)
+  def writer(attr, storage_name)
     define_method("#{attr}=") do |value|
-      Thread.current["#{self.name}.#{attr}"] = value
+      Thread.current[storage_name] = value
     end
   end
 end

--- a/lib/threadsafe_attr.rb
+++ b/lib/threadsafe_attr.rb
@@ -1,0 +1,21 @@
+module ThreadsafeAttr
+  def threadsafe_attr_accessor(*attrs)
+    attrs.each do |attr|
+      reader attr
+      writer attr
+    end
+  end
+
+  private
+  def reader(attr)
+    define_method(attr) do
+      Thread.current["#{self.name}.#{attr}"]
+    end
+  end
+
+  def writer(attr)
+    define_method("#{attr}=") do |value|
+      Thread.current["#{self.name}.#{attr}"] = value
+    end
+  end
+end

--- a/spec/timeliness/parser_spec.rb
+++ b/spec/timeliness/parser_spec.rb
@@ -64,6 +64,18 @@ describe Timeliness::Parser do
       should_not_parse("2000-02-01 25:13:14")
     end
 
+    describe "threadsafety" do
+      it "should allow thread with own format" do
+        eu_date = "30/06/2016"
+        us_date = "06/30/2016"
+        threads = []
+        threads << Thread.new { Timeliness.use_euro_formats; sleep(0.005); Timeliness.parse(eu_date) }
+        threads << Thread.new { sleep(0.001); Timeliness.use_us_formats; Timeliness.parse(us_date) }
+        threads.each { |t| t.join }
+        threads.each { |t| expect(t.value).to eql(Time.new(2016,06,30)) }
+      end
+    end
+
     context "string with zone offset value" do
       context "when current timezone is earler than string zone" do
         before(:all) do


### PR DESCRIPTION
> This allows to safely use Timeliness.use_us_formats and Timeliness.use_euro_formats in threads.

(This is based on @andruby's #23.)

Closes #21 and closes #23.