### PR TITLE
Don't ship test files in the gem artifact

### DIFF
--- a/timeliness.gemspec
+++ b/timeliness.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'i18n'
 
-  s.files            = `git ls-files`.split("\n")
-  s.files            = `git ls-files`.split("\n") - %w{ .gitignore .rspec Gemfile Gemfile.lock }
+  s.files            = %w{README.rdoc LICENSE} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   s.extra_rdoc_files = ["README.rdoc", "CHANGELOG.rdoc"]
   s.require_paths    = ["lib"]
 end


### PR DESCRIPTION
There's no need for test files in the gem artifact. This strips the gem
to just the necessary libs to run and reduces its on disk install size.

Signed-off-by: Tim Smith <tsmith@chef.io>