### PR TITLE
Add support for ISO string with microseconds and no zone offset

### DIFF
--- a/lib/timeliness/definitions.rb
+++ b/lib/timeliness/definitions.rb
@@ -78,6 +78,7 @@ module Timeliness
       'yyyy-mm-ddThh:nn:ssZ', # ISO 8601 without zone offset
       'yyyy-mm-ddThh:nn:sszo', # ISO 8601 with zone offset
       'yyyy-mm-ddThh:nn:ss.u', # ISO 8601 with usec
+      'yyyy-mm-ddThh:nn:ss.uZ', # ISO 8601 with usec and no zone offset
       'yyyy-mm-ddThh:nn:ss.uzo', # ISO 8601 with usec and offset
       'yyyy-mm-dd hh:nn:ss zo', # Ruby time string in later versions
       'yyyy-mm-dd hh:nn:ss tz', # Ruby time string for UTC in later versions

--- a/spec/timeliness/format_set_spec.rb
+++ b/spec/timeliness/format_set_spec.rb
@@ -59,6 +59,7 @@ describe Timeliness::FormatSet do
       format_tests = {
         'ddd mmm d hh:nn:ss zo yyyy'  => {:pass => ['Sat Jul 19 12:00:00 +1000 2008'], :fail => []},
         'yyyy-mm-ddThh:nn:ss(?:Z|zo)' => {:pass => ['2008-07-19T12:00:00+10:00', '2008-07-19T12:00:00Z'], :fail => ['2008-07-19T12:00:00Z+10:00']},
+        'yyyy-mm-ddThh:nn:ss.uZ' => {:pass => ['2019-06-07T03:35:55.100000Z'], :fail => []},
       }
       format_tests.each do |format, values|
         it "should correctly match datetimes in format '#{format}'" do
@@ -68,7 +69,6 @@ describe Timeliness::FormatSet do
         end
       end
     end
-
   end
 
   context "#match" do


### PR DESCRIPTION
Allow for strings like this to work

```
irb(main):001:0> require 'time'
=> true
irb(main):002:0> Time.now.utc.round(1).iso8601(6)
=> "2019-06-07T03:35:55.100000Z"
```