### PR TITLE
Added yyyy-mm-ddThh:nn format

### DIFF
--- a/lib/timeliness/definitions.rb
+++ b/lib/timeliness/definitions.rb
@@ -77,6 +77,7 @@ module Timeliness
       'ddd, dd mmm yyyy hh:nn:ss tz', # RFC 822
       'ddd, dd mmm yyyy hh:nn:ss zo', # RFC 822
       'ddd mmm d hh:nn:ss zo yyyy', # Ruby time string
+      'yyyy-mm-ddThh:nn', # ISO 8601 without seconds
       'yyyy-mm-ddThh:nn:ss', # ISO 8601
       'yyyy-mm-ddThh:nn:sszo', # ISO 8601 with zone offset
       'yyyy-mm-ddThh:nn:sszt', # ISO 8601 with 'Zulu time' (i.e. Z) UTC zone designator

--- a/spec/timeliness/format_set_spec.rb
+++ b/spec/timeliness/format_set_spec.rb
@@ -62,6 +62,8 @@ describe Timeliness::FormatSet do
         'yyyy-mm-ddThh:nn:sszo' => {pass: ['2008-07-19T12:00:00+10:00'], fail: ['2008-07-19T12:00:00Z+10:00']},
         'yyyy-mm-ddThh:nn:ss.uzt' => {pass: ['2019-06-07T03:35:55.100000Z'], fail: []},
         'dd.mm.yyyy hh:nn' => {pass: ['07.06.2019 03:35'], fail: []},
+        'yyyy-mm-dd hh:nn' => {pass: ['2019-06-07 03:35'], fail: []},
+        'yyyy-mm-ddThh:nn' => {pass: ['2019-06-07T03:35'], fail: []},
       }
       format_tests.each do |format, values|
         it "should correctly match datetimes in format '#{format}'" do


### PR DESCRIPTION
Fixes #49.

I was unable to add a failing test. Both the test formats added passes before this change. However this returns nil before adding this format and works after adding this format: `Timeliness.parse('2024-09-04T12:30')`