### PR TITLE
Update to be frozen string literal safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,6 @@ jobs:
         bundler-cache: true # 'bundle install' and cache gems
         ruby-version: ${{ matrix.ruby-version }}
     - name: Run tests
+      env:
+          RUBYOPT: ${{ matrix.ruby == 'ruby-head' && '--enable=frozen-string-literal' || '' }}
       run: bundle exec rspec

--- a/lib/timeliness/format_set.rb
+++ b/lib/timeliness/format_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Timeliness
   class FormatSet
     attr_reader :formats, :regexp
@@ -15,7 +17,7 @@ module Timeliness
     # Compiles the formats into one big regexp. Stores the index of where
     # each format's capture values begin in the matchdata.
     def compile!
-      regexp_string = ''
+      regexp_string = +''
       @formats.inject(0) { |index, format_string|
         format = Format.new(format_string).compile!
         @formats_hash[format_string] = format

--- a/timeliness.gemspec
+++ b/timeliness.gemspec
@@ -28,6 +28,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'tzinfo', '>= 0.3.31'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'timecop'
+  s.add_development_dependency 'base64'
+  s.add_development_dependency 'bigdecimal'
+  s.add_development_dependency 'mutex_m'
   s.add_development_dependency 'i18n'
 
   s.files            = `git ls-files`.split("\n")


### PR DESCRIPTION
When loading this gem with ruby 3.4 preview2 and enabling frozen strings, an error gets thrown around modifying a frozen string. This resolves the issue and updates the tests to run ruby-head tests with strings frozen to prevent this in the future.

<img width="746" alt="image" src="https://github.com/user-attachments/assets/cf9d8eb6-163e-45b0-b010-9104933811f6">
